### PR TITLE
Add editable assignment names and update `MetaData`s

### DIFF
--- a/src/main/java/assignments/AssignmentMetaData.java
+++ b/src/main/java/assignments/AssignmentMetaData.java
@@ -80,11 +80,13 @@ public class AssignmentMetaData implements MetaData {
     }
 
     public int setAssignmentName(String name) throws SQLException{
-        try(Connection conn = H2DatabaseUtil.createConnection()){
+        try (Connection conn = H2DatabaseUtil.createConnection()){
             AssignmentRecord assignmentRecord = getAssignmentRecord(conn);
             assignmentRecord.setName(name);
-            return assignmentRecord.store();
-        }catch (SQLException e){
+            int res = assignmentRecord.store();
+            this.name = name;
+            return res;
+        } catch (SQLException e){
             LOG.error("Could not set name");
             throw e;
         }
@@ -94,7 +96,9 @@ public class AssignmentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()){
             AssignmentRecord assignmentRecord = getAssignmentRecord(conn);
             assignmentRecord.setCategoryId(category.getId());
-            return assignmentRecord.store();
+            int res = assignmentRecord.store();
+            this.category = category;
+            return res;
         } catch(SQLException e){
             LOG.error("Could not set category");
             throw e;
@@ -108,8 +112,10 @@ public class AssignmentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()){
             AssignmentRecord assignmentRecord = getAssignmentRecord(conn);
             assignmentRecord.setExtracredit(extra_credit);
-            return assignmentRecord.store();
-        }catch(SQLException e){
+            int res = assignmentRecord.store();
+            this.extraCredit = extra_credit;
+            return res;
+        } catch(SQLException e){
             LOG.error("Could not set category");
             throw e;
         }
@@ -132,7 +138,7 @@ public class AssignmentMetaData implements MetaData {
     //get all the students who have taken the assignment
 
     public List<Student> getStudent() throws SQLException{
-        try(Connection conn = H2DatabaseUtil.createConnection()){
+        try (Connection conn = H2DatabaseUtil.createConnection()){
             DSLContext create = H2DatabaseUtil.createContext(conn);
 
             return create.select()
@@ -145,7 +151,7 @@ public class AssignmentMetaData implements MetaData {
     //get information inside assignment weight
 
     public List<AssignmentWeight> getWeights() throws SQLException{
-        try(Connection conn = H2DatabaseUtil.createConnection()) {
+        try (Connection conn = H2DatabaseUtil.createConnection()) {
             DSLContext create = H2DatabaseUtil.createContext(conn);
 
             return create.select()
@@ -156,7 +162,7 @@ public class AssignmentMetaData implements MetaData {
     }
 
     public AssignmentWeight getWeightForStudentType(StudentType studentType) throws SQLException{
-        try(Connection conn = H2DatabaseUtil.createConnection()) {
+        try (Connection conn = H2DatabaseUtil.createConnection()) {
             DSLContext create = H2DatabaseUtil.createContext(conn);
 
             return create.select()
@@ -182,7 +188,7 @@ public class AssignmentMetaData implements MetaData {
     //get all the exception weight
 
     public List<AssignmentWeightException> getException() throws SQLException{
-        try(Connection conn = H2DatabaseUtil.createConnection()) {
+        try (Connection conn = H2DatabaseUtil.createConnection()) {
             DSLContext create = H2DatabaseUtil.createContext(conn);
 
             return create.select()

--- a/src/main/java/gui/AssignmentBox.java
+++ b/src/main/java/gui/AssignmentBox.java
@@ -26,26 +26,26 @@ public class AssignmentBox extends JButton {
         setLayout(new GridBagLayout());
         setPreferredSize(new Dimension(width, height));
 
-        JLabel nameLabel = new JLabel(assignmentMetaData.getName());
+        EditableTextField nameLabel = new EditableAssignmentName(assignmentMetaData);
 
         JPanel weightPanel = new JPanel();
         weightPanel.setLayout(new BoxLayout(weightPanel, BoxLayout.X_AXIS));
         weightPanel.setOpaque(false);
         JLabel weightLabel = new JLabel("Weight: ");
-        EditableTextField weightTextField = new EditableWeight(assignmentMetaData, studentType, parentPanel);
+        EditableTextField weightTextField = new EditableAssignmentWeight(assignmentMetaData, studentType, parentPanel);
         JLabel percentLabel = new JLabel("%");
         weightPanel.add(weightLabel);
         weightPanel.add(weightTextField);
         weightPanel.add(percentLabel);
 
         GridBagConstraints nameGBC = new GridBagConstraints();
-//        nameGBC.anchor = GridBagConstraints.WEST;
+        nameGBC.anchor = GridBagConstraints.WEST;
         nameGBC.weightx = 1.0;
         nameGBC.gridx = 0;
 
         GridBagConstraints weightGBC = new GridBagConstraints();
-//        weightGBC.anchor = GridBagConstraints.EAST;
-        weightGBC.weightx = 1.0;
+        weightGBC.anchor = GridBagConstraints.EAST;
+        weightGBC.weightx = .2;
         weightGBC.gridx = 1;
 
         add(nameLabel, nameGBC);

--- a/src/main/java/gui/EditableAssignmentName.java
+++ b/src/main/java/gui/EditableAssignmentName.java
@@ -1,0 +1,28 @@
+package gui;
+
+import assignments.AssignmentMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+
+public class EditableAssignmentName extends EditableTextField {
+
+    private final static Logger LOG = LoggerFactory.getLogger(EditableAssignmentName.class);
+
+    private final AssignmentMetaData assignmentMetaData;
+
+    public EditableAssignmentName(AssignmentMetaData assignmentMetaData) throws SQLException {
+        super(assignmentMetaData.getName());
+        this.assignmentMetaData = assignmentMetaData;
+
+        this.setToolTipText("Edit and click out of this box to change the assignment name");
+    }
+
+    @Override
+    void updateText(String updatedText) throws SQLException {
+        LOG.debug("Clicked out with value: {}", updatedText);
+
+        assignmentMetaData.setAssignmentName(updatedText);
+    }
+}

--- a/src/main/java/gui/EditableAssignmentWeight.java
+++ b/src/main/java/gui/EditableAssignmentWeight.java
@@ -8,40 +8,40 @@ import org.slf4j.LoggerFactory;
 import javax.swing.*;
 import java.sql.SQLException;
 
-public class EditableWeight extends EditableTextField {
+public class EditableAssignmentWeight extends EditableTextField {
 
-    private final static Logger LOG = LoggerFactory.getLogger(EditableWeight.class);
+    private final static Logger LOG = LoggerFactory.getLogger(EditableAssignmentWeight.class);
 
     private AssignmentMetaData assignmentMetaData;
     private StudentType studentType;
     private JPanel parentPanel;
 
-    public EditableWeight(AssignmentMetaData assignmentMetaData,
-                          StudentType studentType) throws SQLException {
+    public EditableAssignmentWeight(AssignmentMetaData assignmentMetaData,
+                                    StudentType studentType) throws SQLException {
         super(assignmentMetaData.getWeightForStudentType(studentType).getWeightPercent().toString());
         this.assignmentMetaData = assignmentMetaData;
         this.studentType = studentType;
 
-        this.setToolTipText("Edit and click out of this box to change the weight!");
+        this.setToolTipText("Edit and click out of this box to change the weight");
     }
 
-    public EditableWeight(AssignmentMetaData assignmentMetaData,
-                          StudentType studentType,
-                          JPanel parentPanel) throws SQLException {
+    public EditableAssignmentWeight(AssignmentMetaData assignmentMetaData,
+                                    StudentType studentType,
+                                    JPanel parentPanel) throws SQLException {
         this(assignmentMetaData, studentType);
         this.parentPanel = parentPanel;
     }
 
     @Override
-    void updateText(String updatedString) throws SQLException {
-        LOG.debug("Clicked out with value: {}", this.getText());
+    void updateText(String updatedText) throws SQLException {
+        LOG.debug("Clicked out with value: {}", updatedText);
 
         double updatedWeight;
-        if (this.getText().isEmpty()) {
+        if (updatedText.isEmpty()) {
             updatedWeight = 0;
             this.setText("0.0");
         } else {
-            updatedWeight = Double.parseDouble(this.getText());
+            updatedWeight = Double.parseDouble(updatedText);
         }
 
         assignmentMetaData.setWeightForStudentType(studentType, updatedWeight);

--- a/src/main/java/gui/EditableTextField.java
+++ b/src/main/java/gui/EditableTextField.java
@@ -25,7 +25,7 @@ public abstract class EditableTextField extends JTextField implements FocusListe
     @Override
     public void focusLost(FocusEvent e) {
         try {
-            updateText(e.paramString());
+            updateText(this.getText());
         } catch (SQLException s) {
             LOG.error(s.getMessage());
             s.printStackTrace();

--- a/src/main/java/students/StudentMetaData.java
+++ b/src/main/java/students/StudentMetaData.java
@@ -81,7 +81,9 @@ public class StudentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()) {
             StudentRecord studentRecord = getStudentRecord(conn);
             studentRecord.setFirstName(firstName);
-            return studentRecord.store();
+            int res = studentRecord.store();
+            this.firstName = firstName;
+            return res;
         } catch (SQLException e) {
             LOG.error("Could not set first name");
             throw e;
@@ -92,7 +94,9 @@ public class StudentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()) {
             StudentRecord studentRecord = getStudentRecord(conn);
             studentRecord.setLastName(lastName);
-            return studentRecord.store();
+            int res = studentRecord.store();
+            this.lastName = lastName;
+            return res;
         } catch (SQLException e) {
             LOG.error("Could not set last name");
             throw e;
@@ -103,7 +107,9 @@ public class StudentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()) {
             StudentRecord studentRecord = getStudentRecord(conn);
             studentRecord.setEmail(email);
-            return studentRecord.store();
+            int res = studentRecord.store();
+            this.email = email;
+            return res;
         } catch (SQLException e) {
             LOG.error("Could not set email");
             throw e;
@@ -114,7 +120,9 @@ public class StudentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()) {
             StudentRecord studentRecord = getStudentRecord(conn);
             studentRecord.setMajorId(major.getId());
-            return studentRecord.store();
+            int res = studentRecord.store();
+            this.major = major;
+            return res;
         } catch (SQLException e) {
             LOG.error("Could not set major");
             throw e;
@@ -125,7 +133,9 @@ public class StudentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()) {
             StudentRecord studentRecord = getStudentRecord(conn);
             studentRecord.setYear(year);
-            return studentRecord.store();
+            int res = studentRecord.store();
+            this.year = year;
+            return res;
         } catch (SQLException e) {
             LOG.error("Could not set year");
             throw e;
@@ -136,7 +146,9 @@ public class StudentMetaData implements MetaData {
         try (Connection conn = H2DatabaseUtil.createConnection()) {
             StudentRecord studentRecord = getStudentRecord(conn);
             studentRecord.setStudentTypeId(studentType.getId());
-            return studentRecord.store();
+            int res = studentRecord.store();
+            this.studentType = studentType;
+            return res;
         } catch (SQLException e) {
             LOG.error("Could not set student type");
             throw e;


### PR DESCRIPTION
- Add editable assignment names
- makes sure `MetaData`s remain consistent when setting a field, because otherwise, when updating assignment name, the page would need to be refreshed first before the information in the `MetaData` gets updated with the assignment name
- renamed `EditableWeight` to `EditableAssignmentWeight` to remain consistent with the new `EditableAssignmentName`